### PR TITLE
override botocore delay_exponential retry to make it less optimistic

### DIFF
--- a/zinc/route53.py
+++ b/zinc/route53.py
@@ -1,13 +1,34 @@
 import json
 import uuid
 import logging
+import random
 
 import boto3
 from boto3.session import Session
+import botocore.retryhandler
 from botocore.exceptions import ClientError
 from django.conf import settings
 
 from django_project.vendors import hashids
+
+
+def delay_exponential(base, *a, **kwa):
+    """
+    Override botocore's delay_exponential retry strategy, to ensure min delay is non-zero.
+    We want to use a random base between 0.2 and 0.8. Final progressions are:
+    min: [0.2, 0.4, 0.8, 1.6,  3.2] - 6.2 s
+    max: [0.8, 1.6, 3.2, 6.4, 12.8] - 24.8 s
+    """
+    if base == 'rand':
+        # 1 / 1.(6) == 0.6
+        base = 0.2 + random.random() / 1.666666666666666666
+    return botocore.retryhandler._orig_delay_exponential(base, *a, **kwa)
+
+
+# we monkeypatch the retry handler because the original logic in botocore is to optimistic
+# in the case of a random backoff (they pick a base in the 0-1.0 second interval)
+botocore.retryhandler._orig_delay_exponential = botocore.retryhandler.delay_exponential
+botocore.retryhandler.delay_exponential = delay_exponential
 
 AWS_KEY = getattr(settings, 'AWS_KEY', '')
 AWS_SECRET = getattr(settings, 'AWS_SECRET', '')
@@ -20,7 +41,7 @@ AWS_SECRET = getattr(settings, 'AWS_SECRET', '')
 client = boto3.client(
     service_name='route53',
     aws_access_key_id=AWS_KEY or '-',
-    aws_secret_access_key=AWS_SECRET or '-'
+    aws_secret_access_key=AWS_SECRET or '-',
 )
 
 logger = logging.getLogger('zinc.route53')


### PR DESCRIPTION
When using a random base, ensure the base is in the 0.2 - 0.8 interval,
as by default it could be as low as 0.0