### PR TITLE
upsert records part of a policy when secondary attributes change

### DIFF
--- a/zinc/utils/__init__.py
+++ b/zinc/utils/__init__.py
@@ -1,0 +1,16 @@
+from functools import wraps
+
+
+def memoized_property(method):
+    """
+    Caches a method's return value on the instance.
+    """
+    @property
+    @wraps(method)
+    def caching_wrapper(self):
+        cache_key = "__cached_" + method.__name__
+        if not hasattr(self, cache_key):
+            return_value = method(self)
+            setattr(self, cache_key, return_value)
+        return getattr(self, cache_key)
+    return caching_wrapper

--- a/zinc/views.py
+++ b/zinc/views.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 from rest_framework.generics import (ListAPIView, CreateAPIView, RetrieveUpdateDestroyAPIView)
 from rest_framework import viewsets, status, mixins
 from rest_framework.response import Response
@@ -9,21 +7,7 @@ from rest_framework.exceptions import NotFound
 from zinc.serializers import (PolicySerializer, ZoneDetailSerializer,
                               ZoneListSerializer, RecordSerializer)
 from zinc import models
-
-
-def memoized_property(method):
-    """
-    Caches a method's return value on the instance.
-    """
-    @property
-    @wraps(method)
-    def caching_wrapper(self):
-        cache_key = "__cached_" + method.__name__
-        if not hasattr(self, cache_key):
-            return_value = method(self)
-            setattr(self, cache_key, return_value)
-        return getattr(self, cache_key)
-    return caching_wrapper
+from zinc.utils import memoized_property
 
 
 class PolicyViewset(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Previously if a record was found in AWS with the same (name, type, set_id) it
would be skipped in the policy reconcile. Now we look if the expected
attributes are a subset of what we have in AWS and upsert if that's not the
case.