### PR TITLE
use CREATE not UPSERT when creating a new record fixes #231

### DIFF
--- a/tests/api/test_zone_records.py
+++ b/tests/api/test_zone_records.py
@@ -177,7 +177,7 @@ def test_patch_nonexistent_records(api_client, zone):
 @pytest.mark.django_db
 def test_add_record_without_values(api_client, zone):
     record = {
-        'name': 'test',
+        'name': 'test1',
         'ttl': 400,
         'type': 'A',
     }
@@ -191,7 +191,7 @@ def test_add_record_without_values(api_client, zone):
 @pytest.mark.django_db
 def test_add_record_without_ttl(api_client, zone):
     record = {
-        'name': 'test',
+        'name': 'test1',
         'type': 'A',
         'values': ['4.5.6.7']
     }

--- a/tests/dns/test_policy_record_tree.py
+++ b/tests/dns/test_policy_record_tree.py
@@ -900,7 +900,7 @@ def test_r53_policy_reconcile_cname_clash(zone, boto_client):
             zone.root)]
     # only look at the hidden records (the ones part of the policy tree)
     records = [(r.name, r.values) for r in raw_aws_records]
-    assert records == [
+    expected = [
         ('_zn_pol1', ['ALIAS _zn_pol1_us-east-1.test-zinc.net.']),
         ('_zn_pol1', ['ALIAS _zn_pol1_us-east-2.test-zinc.net.']),
         ('_zn_pol1_us-east-1', [ip1.ip]),
@@ -909,6 +909,7 @@ def test_r53_policy_reconcile_cname_clash(zone, boto_client):
         ('test', ['1.1.1.1']),
         ('www', ['ALIAS _zn_pol1.test-zinc.net.']),
     ]
+    assert records == expected
 
 
 @pytest.mark.django_db

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,3 +108,22 @@ def get_record_from_base(record, *a, **kwa):
         return record_to_response(record, *a, **kwa)
     else:
         return record_data_to_response(record, *a, **kwa)
+
+
+def meld(got, expected):
+    if got == expected:
+        return
+    import inspect
+    call_frame = inspect.getouterframes(inspect.currentframe(), 2)
+    test_name = call_frame[1][3]
+    from pprint import pformat
+    import os
+    from os import path
+    os.makedirs(test_name, exist_ok=True)
+    got_fn = path.join(test_name, 'got')
+    expected_fn = path.join(test_name, 'expected')
+    with open(got_fn, 'w') as got_f, open(expected_fn, 'w') as expected_f:
+        got_f.write(pformat(got))
+        expected_f.write(pformat(expected))
+    import subprocess
+    subprocess.run(['meld', got_fn, expected_fn])

--- a/zinc/route53/record.py
+++ b/zinc/route53/record.py
@@ -65,12 +65,13 @@ class BaseRecord:
     ])
     _r53_to_obj = {v: k for k, v in _obj_to_r53.items()}
 
-    def __init__(self, name=None, alias_target=None, deleted=False, dirty=False,
+    def __init__(self, name=None, alias_target=None, created=False, deleted=False, dirty=False,
                  health_check_id=None, managed=False, region=None, set_identifier=None,
                  traffic_policy_instance_id=None, ttl=None, values=None, weight=None,
                  zone=None):
         self.name = name
         self.alias_target = alias_target
+        self.created = created
         assert alias_target is None or ttl is None
         self.ttl = ttl
         self._values = values
@@ -234,7 +235,8 @@ class Record(BaseRecord):
 
 
 class PolicyRecord(BaseRecord):
-    def __init__(self, zone, policy_record=None, policy=None, dirty=None, deleted=None):
+    def __init__(self, zone, policy_record=None, policy=None, dirty=None,
+                 deleted=None, created=None):
         if policy is None:
             policy = policy_record.policy
         if dirty is None:
@@ -257,6 +259,7 @@ class PolicyRecord(BaseRecord):
             },
             deleted=deleted,
             dirty=dirty,
+            created=created,
         )
 
     def full_clean(self):
@@ -339,7 +342,7 @@ class PolicyRecord(BaseRecord):
         self._policy = value
 
 
-def record_factory(zone, **validated_data):
+def record_factory(zone, created=None, **validated_data):
     record_type = validated_data.pop('type')
     if record_type == POLICY_ROUTED:
         assert len(validated_data['values']) == 1
@@ -355,7 +358,8 @@ def record_factory(zone, **validated_data):
             zone=zone.route53_zone,
             policy=policy,
             dirty=True,
+            created=created,
         )
     else:
-        obj = Record(zone=zone.route53_zone, type=record_type, **validated_data)
+        obj = Record(zone=zone.route53_zone, type=record_type, created=created, **validated_data)
     return obj

--- a/zinc/serializers/record.py
+++ b/zinc/serializers/record.py
@@ -83,7 +83,7 @@ class RecordSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         zone = self.context['zone']
-        obj = route53.record_factory(zone=zone, **validated_data)
+        obj = route53.record_factory(zone=zone, created=True, **validated_data)
         with interpret_client_error():
             obj.full_clean()
             obj.save()

--- a/zinc/serializers/zone.py
+++ b/zinc/serializers/zone.py
@@ -1,10 +1,10 @@
+from botocore.exceptions import ClientError
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from zinc.models import Zone
 from zinc.serializers import RecordSerializer
-from zinc import route53
 
 
 class ZoneListSerializer(serializers.HyperlinkedModelSerializer):
@@ -19,7 +19,7 @@ class ZoneListSerializer(serializers.HyperlinkedModelSerializer):
         zone = Zone.objects.create(**validated_data)
         try:
             zone.route53_zone.create()
-        except route53.ClientError as e:
+        except ClientError as e:
             raise serializers.ValidationError(detail=str(e))
         return zone
 


### PR DESCRIPTION
Using Action='CREATE' when creating a record ensures we don't accidentally
update and existing record.

Updates fake boto to raise an exception when attempting to CREATE an already
existing record.

Also makes sure fake boto returns records in the same order as route53. See
the documentation for list_resoure_record_sets

Adds test helper to utils to run meld on 2 pretty printed data structures,
since I got tired of manually running it and copy pasting.