### PR TITLE
allow deleting PolicyRecords that conflict with CNAME records

### DIFF
--- a/zinc/models.py
+++ b/zinc/models.py
@@ -313,9 +313,13 @@ class PolicyRecord(models.Model):
 
     def clean(self):
         zone_records = self.zone.r53_zone.records()
-        for record in zone_records.values():
-            if record.name == self.name and record.type == 'CNAME':
-                raise ValidationError({'name': "A CNAME record of the same name already exists."})
+        # guard against PolicyRecords/CNAME name clashes
+        if not self.deleted:
+            # don't do the check unless the PR is deleted
+            for record in zone_records.values():
+                if record.name == self.name and record.type == 'CNAME':
+                    raise ValidationError(
+                        {'name': "A CNAME record of the same name already exists."})
 
         super().clean()
 

--- a/zinc/route53/record.py
+++ b/zinc/route53/record.py
@@ -206,6 +206,9 @@ class BaseRecord:
 
     def validate_unique(self):
         """You're not allowed to have a CNAME clash with any other type of record"""
+        if self.deleted:
+            # allow deleting any conflicting record
+            return
         if self.type == 'CNAME':
             clashing = tuple((self.name, r_type) for r_type in RECORD_TYPES)
         else:
@@ -261,10 +264,6 @@ class PolicyRecord(BaseRecord):
             dirty=dirty,
             created=created,
         )
-
-    def full_clean(self):
-        super().full_clean()
-        self.db_policy_record.full_clean()
 
     def save(self):
         if self.deleted:


### PR DESCRIPTION
Previously the api validation was the same for Create/Update and Delete,
so the check for conflicts was preventing deletion.

fixes #258