### PR TITLE
Use a pre-generated secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Should be self explanatory. An IP can be enabled or disabled.
 There is no explicit handling in zinc of multiple IPs belonging to one server.
 
 Enabling or disabling can be done from the admin or by implementing a django app (see
-lattice_sync for an example). 
+lattice_sync for an example).
 
-**N.B.** If implementing your own app it's your responsibility to call 
+**N.B.** If implementing your own app it's your responsibility to call
 `ip.mark_policy_records_dirty` if the IP changes, so that zinc's reconcile loop will
 actually pick up the changes.
 
@@ -44,7 +44,7 @@ same FQDN (defaults to node.presslabs.net, set `ZINC_HEALTH_CHECK_FQDN` to chang
 A policy groups several IPs together. There are 2 types of policies:
  * Weighted
  * Latency
- 
+
 Note that an IP can be a member of multiple Policies at the same time. A PolicyMember
 can has it's own enabled flag, so you can disable an IP for one Policy only, or you can
 disable the it for all Policies by setting the enabled flag on the IP model.

--- a/django_project/settings/base.py
+++ b/django_project/settings/base.py
@@ -30,7 +30,8 @@ WEBROOT_DIR = env.str('ZINC_WEBROOT_DIR', os.path.join(PROJECT_ROOT, 'webroot/')
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env.str('ZINC_SECRET_KEY')
+SECRET_KEY = env.str('ZINC_SECRET_KEY',
+                     default='p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('ZINC_DEBUG', True)

--- a/django_project/settings/base.py
+++ b/django_project/settings/base.py
@@ -11,8 +11,11 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
-from django.utils.log import DEFAULT_LOGGING
+
 import environ
+
+import warnings
+from django.utils.log import DEFAULT_LOGGING
 
 
 root = environ.Path(__file__) - 3  # two folder back (/a/b/ - 2 = /)
@@ -33,8 +36,8 @@ WEBROOT_DIR = env.str('ZINC_WEBROOT_DIR', os.path.join(PROJECT_ROOT, 'webroot/')
 DEFAULT_SECRET_KEY = 'p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r'
 SECRET_KEY = env.str('ZINC_SECRET_KEY', default=DEFAULT_SECRET_KEY)
 if SECRET_KEY == DEFAULT_SECRET_KEY:
-    print("You are using the default secret key. Please set ZINC_SECRET_KEY"
-          " in .env file")
+    warnings.warn("You are using the default secret key. Please set "
+                  "ZINC_SECRET_KEY in .env file")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('ZINC_DEBUG', True)

--- a/django_project/settings/base.py
+++ b/django_project/settings/base.py
@@ -31,8 +31,7 @@ WEBROOT_DIR = env.str('ZINC_WEBROOT_DIR', os.path.join(PROJECT_ROOT, 'webroot/')
 
 # SECURITY WARNING: keep the secret key used in production secret!
 DEFAULT_SECRET_KEY = 'p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r'
-SECRET_KEY = env.str('ZINC_SECRET_KEY',
-                     default='p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r')
+SECRET_KEY = env.str('ZINC_SECRET_KEY', default=DEFAULT_SECRET_KEY)
 if SECRET_KEY == DEFAULT_SECRET_KEY:
     print("You are using the default secret key. Please set ZINC_SECRET_KEY"
           " in .env file")

--- a/django_project/settings/base.py
+++ b/django_project/settings/base.py
@@ -175,7 +175,7 @@ TEMPLATES = [
 WSGI_APPLICATION = 'django_project.wsgi.application'
 
 DATABASES = {
-    'default': env.db('ZINC_DB_URL', 'sqlite://%s' % os.path.join(DATA_DIR, 'db.sqlite3'))
+    'default': env.db('ZINC_DB_URL', 'sqlite:///%s' % os.path.join(DATA_DIR, 'db.sqlite3'))
 }
 
 # Password validation

--- a/django_project/settings/base.py
+++ b/django_project/settings/base.py
@@ -30,8 +30,12 @@ WEBROOT_DIR = env.str('ZINC_WEBROOT_DIR', os.path.join(PROJECT_ROOT, 'webroot/')
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
+DEFAULT_SECRET_KEY = 'p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r'
 SECRET_KEY = env.str('ZINC_SECRET_KEY',
                      default='p@7-h3(%-ile((1fz2ei42)o^a-!cse@kp9jnhrx6x75)#1x(r')
+if SECRET_KEY == DEFAULT_SECRET_KEY:
+    print("You are using the default secret key. Please set ZINC_SECRET_KEY"
+          " in .env file")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('ZINC_DEBUG', True)


### PR DESCRIPTION
It's easier to start this project without an .env file.
In production, this setting is overitten.